### PR TITLE
Initial middleware for handlers

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,3 @@
-# background
-Convert go handler to background job
-
-```go
 package main
 
 import (
@@ -17,11 +13,9 @@ import (
 )
 
 func slowHandler(w http.ResponseWriter, _ *http.Request) {
-	for i := 0; i < 10; i++ {
-		time.Sleep(time.Second * 1)
-	}
+	time.Sleep(time.Second * 10)
 	log.Println("Completed")
-	w.Write([]byte("Completed"))
+	_, _ = w.Write([]byte("Completed"))
 }
 
 func allJobsHandler(service *inmemory.Service) http.HandlerFunc {
@@ -31,13 +25,13 @@ func allJobsHandler(service *inmemory.Service) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		json.NewEncoder(w).Encode(job)
+		_ = json.NewEncoder(w).Encode(job)
 	}
 }
 
 func main() {
-	logger := log.New(os.Stdout, "jobs:", log.LstdFlags)
 	service := inmemory.New()
+	logger := log.New(os.Stdout, "jobs:", log.LstdFlags)
 	bg := background.NewMiddleware(service, logger)
 
 	asyncSlowHandler := bg.InBackground(http.HandlerFunc(slowHandler), "SLOW_HANDLER")
@@ -49,4 +43,3 @@ func main() {
 	fmt.Println("to track jobs use http://localhost:3000/jobs")
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }
-```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/adzeitor/background
+
+go 1.13
+
+require (
+	github.com/google/uuid v1.1.1
+	github.com/stretchr/testify v1.5.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,163 @@
+package background
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// Background converts handlers to background handlers.
+type Background struct {
+	Service JobService
+	Logger  Logger
+
+	executor func(func() error)
+}
+
+// JobService manages background jobs information.
+type JobService interface {
+	JobStarted(ctx context.Context, kind string) (Job, error)
+	JobCompleted(ctx context.Context, id string, response Response) error
+	Ping(ctx context.Context, id string) error
+}
+
+// Logger manages logging.
+type Logger interface {
+	Println(...interface{})
+}
+
+// NewMiddleware creates new middleware that use service as backend for
+// job information updating.
+// Currently all handlers executed in goroutines.
+func NewMiddleware(service JobService, logger Logger) *Background {
+	bg := &Background{
+		Service: service,
+		Logger:  logger,
+	}
+	bg.executor = bg.goroutineExecutor
+	return bg
+}
+
+// InBackground converts handler to background handler.
+// It respond immediately with job ID that can be used to track
+// status and getting response.
+func (bg *Background) InBackground(
+	origHandler http.Handler,
+	kind string,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		job, err := bg.Service.JobStarted(r.Context(), kind)
+		if err != nil {
+			bg.Logger.Println(err)
+			http.Error(w, "cannot start background job", http.StatusInternalServerError)
+			return
+		}
+
+		clonedRequest, err := cloneRequest(r)
+		if err != nil {
+			http.Error(w, "failed to get request body", http.StatusInternalServerError)
+			return
+		}
+		bg.executor(func() error {
+			return bg.serve(job, clonedRequest, origHandler)
+		})
+
+		err = jobStartedResponse(w, job)
+		if err != nil {
+			bg.Logger.Println(err)
+		}
+	})
+}
+
+func (bg *Background) goroutineExecutor(handler func() error) {
+	go func() {
+		err := handler()
+		if err != nil {
+			bg.Logger.Println(err)
+		}
+	}()
+}
+
+func (bg *Background) serve(
+	job Job,
+	r *http.Request,
+	origHandler http.Handler,
+) error {
+	// FIXME: It should be r.Context() instead of new context.Background, but
+	// original context probably will be closed, because serve of original
+	// request is completed. Which can lead to immediately closing of superviseJob.
+	// Maybe implementing ContextWithoutDone will fix this issue.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go bg.superviseJob(ctx, job)
+
+	recorder := httptest.NewRecorder()
+	origHandler.ServeHTTP(recorder, r)
+
+	result := recorder.Result()
+	response, err := newResponse(result)
+	if err != nil {
+		// FIXME: default parameters is no good...
+		// Maybe JobFailed method?
+		return bg.Service.JobCompleted(ctx, job.ID, Response{})
+	}
+	return bg.Service.JobCompleted(ctx, job.ID, response)
+}
+
+func (bg *Background) superviseJob(ctx context.Context, job Job) {
+	tick := time.NewTicker(5 * time.Second)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			err := bg.Service.Ping(ctx, job.ID)
+			if err != nil {
+				bg.Logger.Println("ping error", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func jobStartedResponse(w http.ResponseWriter, job Job) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusCreated)
+
+	response := struct {
+		ID string `json:"id"`
+	}{
+		ID: job.ID,
+	}
+	return json.NewEncoder(w).Encode(response)
+}
+
+func cloneRequest(r *http.Request) (*http.Request, error) {
+	clonedRequest := r.Clone(r.Context())
+	if r.Body != nil {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		clonedRequest.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	}
+
+	return clonedRequest, nil
+}
+
+func newResponse(response *http.Response) (Response, error) {
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return Response{}, err
+	}
+	return Response{
+		StatusCode: response.StatusCode,
+		Header:     response.Header,
+		Body:       string(body),
+	}, nil
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,55 @@
+package background
+
+import (
+	"log"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackground_InBackground(t *testing.T) {
+	jobID := "6d1ed4de-a8cc-42b8-a743-6713a93626d0"
+	wantBody := "job result: 0x3333"
+	service := newServiceMock(t)
+	service.jobStarted = func(kind string) (Job, error) {
+		return Job{ID: jobID}, nil
+	}
+	service.jobCompleted = func(id string, response Response) error {
+		assert.Equal(t, jobID, id)
+		assert.Equal(t, wantBody, response.Body)
+		return nil
+	}
+	service.ping = func(id string) error {
+		assert.Equal(t, jobID, id)
+		return nil
+	}
+
+	bg := NewMiddleware(service, &log.Logger{})
+	bg.executor = func(handler func() error) {
+		_ = handler()
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(wantBody))
+	}
+
+	backgroundHandler := bg.InBackground(http.HandlerFunc(handler), "testkind")
+	gotBody := assert.HTTPBody(backgroundHandler.ServeHTTP, "GET", "/", nil)
+	assert.JSONEq(t, `{"id":"6d1ed4de-a8cc-42b8-a743-6713a93626d0"}`, gotBody)
+}
+
+func TestBackground_goroutineExecutor(t *testing.T) {
+	bg := NewMiddleware(nil, &log.Logger{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	handler := func() error {
+		wg.Done()
+		return nil
+	}
+
+	bg.goroutineExecutor(handler)
+	wg.Wait()
+}

--- a/job.go
+++ b/job.go
@@ -1,0 +1,32 @@
+package background
+
+import (
+	"net/http"
+	"time"
+)
+
+// Status represents status of background job.
+type Status string
+
+// List of available statuses of background jobs.
+const (
+	StatusWorking   = Status("WORKING")
+	StatusCompleted = Status("COMPLETED")
+)
+
+// Job represents background job.
+type Job struct {
+	ID        string    `json:"id"`
+	Status    Status    `json:"status"`
+	Response  *Response `json:"response"`
+	Kind      string    `json:"kind"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Response represents response of origin handler which runs in background.
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       string
+}

--- a/service_mock.go
+++ b/service_mock.go
@@ -1,0 +1,34 @@
+package background
+
+import (
+	"context"
+	"testing"
+)
+
+// serviceMock represents mock of Service interface.
+type serviceMock struct {
+	jobStarted   func(kind string) (Job, error)
+	jobCompleted func(id string, response Response) error
+	ping         func(id string) error
+}
+
+// newServiceMock creates new instance of serviceMock.
+func newServiceMock(t testing.TB) *serviceMock {
+	m := serviceMock{}
+	return &m
+}
+
+// JobStarted mocks method of Service.
+func (m *serviceMock) JobStarted(ctx context.Context, kind string) (Job, error) {
+	return m.jobStarted(kind)
+}
+
+// JobCompleted mocks method of Service.
+func (m *serviceMock) JobCompleted(ctx context.Context, id string, response Response) error {
+	return m.jobCompleted(id, response)
+}
+
+// Ping mocks method of Service.
+func (m *serviceMock) Ping(ctx context.Context, id string) error {
+	return m.ping(id)
+}

--- a/services/inmemory/inmemory.go
+++ b/services/inmemory/inmemory.go
@@ -1,0 +1,108 @@
+package inmemory
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/adzeitor/background"
+	"github.com/google/uuid"
+)
+
+// Service represents in-memory service for store information about background
+// jobs.
+type Service struct {
+	jobs map[string]background.Job
+	sync.Mutex
+}
+
+// New creates new in-memory jobs service.
+func New() *Service {
+	jobs := make(map[string]background.Job)
+	return &Service{
+		jobs: jobs,
+	}
+}
+
+// JobStarted saves initial information about new background job.
+func (s *Service) JobStarted(
+	_ context.Context,
+	kind string,
+) (background.Job, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	now := time.Now()
+	job := background.Job{
+		ID:        uuid.New().String(),
+		Status:    background.StatusWorking,
+		Kind:      kind,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.jobs[job.ID] = job
+	return job, nil
+}
+
+// JobCompleted saves that background job is completed.
+func (s *Service) JobCompleted(
+	_ context.Context,
+	id string,
+	response background.Response,
+) error {
+	s.Lock()
+	defer s.Unlock()
+
+	job := s.jobs[id]
+	job.Status = background.StatusCompleted
+	job.Response = &response
+	job.UpdatedAt = time.Now()
+	s.jobs[id] = job
+	return nil
+}
+
+// Get retrieves job information by job ID.
+func (s *Service) Get(_ context.Context, id string) (background.Job, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	job, ok := s.jobs[id]
+	if !ok {
+		return background.Job{}, errors.New("not found")
+	}
+	return job, nil
+}
+
+// Jobs retrieves all jobs.
+func (s *Service) Jobs() ([]background.Job, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	var jobs []background.Job
+	for _, job := range s.jobs {
+		jobs = append(jobs, job)
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].CreatedAt.Before(jobs[j].CreatedAt)
+	})
+	return jobs, nil
+}
+
+// Jobs sets that job is working.
+func (s *Service) Ping(_ context.Context, id string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	job := s.jobs[id]
+	if job.Status == background.StatusCompleted {
+		return nil
+	}
+
+	job.Status = background.StatusWorking
+	job.UpdatedAt = time.Now()
+	s.jobs[id] = job
+	return nil
+}


### PR DESCRIPTION
Middleware can be used to make any handler work in background.
Progress of background job managed by service which should
implement Service interface.