### PR TITLE
Fix clone request with cancelled context

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -137,7 +137,7 @@ func jobStartedResponse(w http.ResponseWriter, job Job) error {
 }
 
 func cloneRequest(r *http.Request) (*http.Request, error) {
-	clonedRequest := r.Clone(r.Context())
+	clonedRequest := r.Clone(WithNoCancelContext(r.Context()))
 	if r.Body != nil {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/no_cancel_ctx.go
+++ b/no_cancel_ctx.go
@@ -1,0 +1,33 @@
+package background
+
+import (
+	"context"
+	"time"
+)
+
+// noCancelCtx ignores any context cancellations.
+type noCancelCtx struct {
+	parent context.Context
+}
+
+func WithNoCancelContext(ctx context.Context) context.Context {
+	return &noCancelCtx{parent: ctx}
+}
+
+func (c *noCancelCtx) Value(key interface{}) interface{} {
+	return c.parent.Value(key)
+}
+
+func (c *noCancelCtx) Done() <-chan struct{} {
+	// From golang context package documentation:
+	// Done may return nil if this context can never be canceled.
+	return nil
+}
+
+func (*noCancelCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (c *noCancelCtx) Err() error {
+	return nil
+}


### PR DESCRIPTION
For example, if background handler do http requests with context
then context will be canceled because it is cloned from original
request which is closed.