### PR TITLE
Make races between ping and complete impossible

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -45,7 +45,7 @@ func NewMiddleware(service JobService, logger Logger) *Background {
 }
 
 // InBackground converts handler to background handler.
-// It respond immediately with job ID that can be used to track
+// It responds immediately with job ID that can be used to track
 // status and getting response.
 func (bg *Background) InBackground(
 	origHandler http.Handler,

--- a/handler.go
+++ b/handler.go
@@ -95,11 +95,11 @@ func (bg *Background) serve(
 
 	recorder := httptest.NewRecorder()
 	origHandler.ServeHTTP(recorder, r)
+	// make sure that ping job is completed
+	supervisorCancel()
 
 	result := recorder.Result()
 	response, err := newResponse(result)
-	// make sure that ping job is completed
-	supervisorCancel()
 	if err != nil {
 		// FIXME: default parameters is no good...
 		// Maybe JobFailed method?

--- a/handler_test.go
+++ b/handler_test.go
@@ -67,6 +67,7 @@ func TestBackground_InBackground(t *testing.T) {
 		}
 		service.ping = func(id string) error {
 			waitForFirstPing <- true
+			time.Sleep(time.Second)
 			calls = append(calls, "ping")
 			return nil
 		}
@@ -88,6 +89,7 @@ func TestBackground_InBackground(t *testing.T) {
 		backgroundHandler.ServeHTTP(w, req)
 
 		// assert
+		assert.True(t, len(calls) >= 3, "there should be at least 3 calls: started, ping(1..N), completed", calls)
 		assert.Equal(t, "completed", calls[len(calls)-1], "completed should always be the last %v", calls)
 	})
 }


### PR DESCRIPTION
Make sure that complete will be send only AFTER ping response,
not DURING it.